### PR TITLE
Fix typos in lagom 1.2.1 announcement post

### DIFF
--- a/src/blog/lagom-1-2-1.md
+++ b/src/blog/lagom-1-2-1.md
@@ -7,9 +7,9 @@ summary: >
     The Lagom team is proud to announce the release of Lagom 1.2.1! This is a minor release providing some bugfixes and also a performance enhancement.
 ---
 
-The Lagom team is proud to annoucen the availability of the 1.2.1 version. This release provides several bugfixes and a performance enhancement.
+The Lagom team is proud to announce the availability of the 1.2.1 version. This release provides several bugfixes and a performance enhancement.
 
-It's been a month since releasing 1.2.0 and the [mailing list](https://github.com/lagom/lagom/issues) and Lagom's [Gitter channel](https://gitter.im/lagom/lagom) have been _on fire_. Many are already developing their microservice-based solutions using Lagom, but Lagom is not (yet) free of bugs and the community has been great at helping spot some of these bug both on documentation or the code itself. This release addresses [some of these issues](https://github.com/lagom/lagom/milestone/5?closed=1) improving documentation and performance, and fixing a regression introduced when releasing 1.2.0. Don't forget to use Lagom's [issue tracker](https://github.com/lagom/lagom/issues) to report and contribute to fixing issues.
+It's been a month since releasing 1.2.0 and the [mailing list](https://github.com/lagom/lagom/issues) and Lagom's [Gitter channel](https://gitter.im/lagom/lagom) have been _on fire_. Many are already developing their microservice-based solutions using Lagom, but Lagom is not (yet) free of bugs and the community has been great at helping spot some of these bugs both on documentation or the code itself. This release addresses [some of these issues](https://github.com/lagom/lagom/milestone/5?closed=1) improving documentation and performance, and fixing a regression introduced when releasing 1.2.0. Don't forget to use Lagom's [issue tracker](https://github.com/lagom/lagom/issues) to report and contribute to fixing issues.
 
 Thanks to all of you that reported and contributed on making this release possible.
 


### PR DESCRIPTION
Fix typo's:

- annoucen -> announce
- bug -> bugs