### PR TITLE
Applies link style to code bits

### DIFF
--- a/src/main/assets/_documentation.styl
+++ b/src/main/assets/_documentation.styl
@@ -39,6 +39,11 @@ article
     border: 1px solid lb-light-grey
     font-size 0.85em
     padding 0.0625rem 0.3125rem
+  a
+    code
+      color lgm-purple
+      font-weight: bolder
+
 
 .breadcrumbs
   font-size: 0.8em


### PR DESCRIPTION
Fixes #24 

With these changes it's obvious when a code snippet is a link and when it's not.

![screen shot 2017-02-08 at 19 13 06](https://cloud.githubusercontent.com/assets/762126/22750870/a512e5a4-ee32-11e6-85e6-5b06c9e8d54b.png)

