### PR TITLE
Fix Java usages in Scala 1.3.x docs

### DIFF
--- a/src/docs/1.3.x/scala/CassandraServer.html
+++ b/src/docs/1.3.x/scala/CassandraServer.html
@@ -38,10 +38,10 @@
 &lt;/plugin&gt;
 </code></pre>
 <p>In sbt, let&rsquo;s assume you have the following Lagom project in your build:</p>
-<pre class="prettyprint"><code class="language-sbt">lazy val usersImpl = (project in file(&quot;usersImpl&quot;)).enablePlugins(LagomJava)
+<pre class="prettyprint"><code class="language-sbt">lazy val usersImpl = (project in file(&quot;usersImpl&quot;)).enablePlugins(LagomScala)
   .settings(name := &quot;users-impl&quot;)</code></pre>
 <p>Because the project&rsquo;s name is <code>users-impl</code>, the generated Cassandra keyspace will be <code>users_impl</code> (note that dashes are replaced with underscores). If you&rsquo;d prefer the keyspace to be named simply <code>users</code>, you could either change the project&rsquo;s <code>name</code> to be <code>users</code>, or alternatively add the following setting:</p>
-<pre class="prettyprint"><code class="language-sbt">lazy val usersImpl = (project in file(&quot;usersImpl&quot;)).enablePlugins(LagomJava)
+<pre class="prettyprint"><code class="language-sbt">lazy val usersImpl = (project in file(&quot;usersImpl&quot;)).enablePlugins(LagomScala)
   .settings(
     name := &quot;users-impl&quot;,
     lagomCassandraKeyspace := &quot;users&quot;

--- a/src/docs/1.3.x/scala/Logging.html
+++ b/src/docs/1.3.x/scala/Logging.html
@@ -2,13 +2,13 @@
 <p>Lagom uses SLF4J for logging, backed by <a href="http://logback.qos.ch/">Logback</a> as its default logging engine. Here is a short example showcasing how you can access the logger:</p>
 <pre class="prettyprint"><code class="language-java">package docs.logging;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 public class LoggingExample {
-    private final Logger log = LoggerFactory.getLogger(LoggingExample.class);
+    private final log: Logger = LoggerFactory.getLogger(classOf[LoggingExample])
 
-    public void demonstrateLogging(String msg) {
+    def demonstrateLogging(msg: String): Unit {
         log.debug(&quot;Here is a message at debug level: {}.&quot;, msg);
     }
 }</code></pre>
@@ -33,13 +33,17 @@ lazy val usersApi = (project in file(&quot;usersApi&quot;))
 <p>Lagom can be configured to use <a href="https://logging.apache.org/log4j/2.x/">Log4j 2</a> as its default logging engine. Using Log4j 2 can use either the SLF4J API for logging as shown above or the Log4j 2 API. For example, using the Log4j 2 API:</p>
 <pre class="prettyprint"><code class="language-java">package docs.logging;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 
-public class Log4j2Example {
-    private static final Logger LOGGER = LogManager.getLogger();
+object Log4j2Example {
+    private final val LOGGER: Logger = LogManager.getLogger()
+}
 
-    public void demonstrateLogging(String msg) {
+class Log4j2Example {
+    import Log4j2Example._
+
+    def demonstrateLogging(msg: String): Unit {
         LOGGER.debug(&quot;Here is a message at the debug level: {}&quot;, msg);
     }
 }</code></pre>


### PR DESCRIPTION
This PR fixes some documentation inconsistencies that reference Java instead of Scala in the Scala 1.3.0 documentation