### PR TITLE
Remove duplicated text from the introduction

### DIFF
--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjava.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjava.scala.html
@@ -27,13 +27,8 @@
                         <li><a href="https://maven.apache.org">Maven</a></li>
                     </ul>
 
-                    <p>
-                        See <a href="@context.path/documentation/@context.currentDocsVersion/java/IntroGetStarted.html">detailed instructions</a>
-                            for help setting up the prerequisites and getting started.
-                            Or, if you are raring to go, just follow the simple steps for your build tool:
-                    </p>
-
                     <div class="get-started-buttons">
+                        <p>Learn more about getting started with:</p>
                         <a href="#maven" class="lagom-logo-button">Maven</a>
                         <a href="#sbt" class="lagom-logo-button">sbt</a>
                     </div>


### PR DESCRIPTION
This also centers the getting started text above the buttons.

Request from @rstento 

Here's a screen shot of the result:

![screen shot 2017-02-24 at 12 22 28 pm](https://cloud.githubusercontent.com/assets/44385/23286560/9e957460-fa8c-11e6-998f-f2aa39f19de3.png)
