### PR TITLE
Enforce ASCII for blog posts

### DIFF
--- a/src/blog/microservices-from-development-to-production.md
+++ b/src/blog/microservices-from-development-to-production.md
@@ -4,25 +4,25 @@ date: 2016-07-26
 author_github: huntc
 tags: conductr screencast
 summary: >
-    Let’s face it, microservices sound great, but they’re sure hard to set up and get going. There are service gateways to consider, setting up service discovery, consolidated logging, rolling updates, resiliency concerns… the list is almost endless. Distributed systems benefit the business, not so much the developer.
+    Let's face it, microservices sound great, but they're sure hard to set up and get going. There are service gateways to consider, setting up service discovery, consolidated logging, rolling updates, resiliency concerns... the list is almost endless. Distributed systems benefit the business, not so much the developer.
 
 ---
 
 ## Microservices sound great
-Let’s face it, microservices sound great, but they’re sure hard to set up and get going. There are service gateways to consider, setting up service discovery, consolidated logging, rolling updates, resiliency concerns… the list is almost endless. Distributed systems benefit the business, not so much the developer.
+Let's face it, microservices sound great, but they're sure hard to set up and get going. There are service gateways to consider, setting up service discovery, consolidated logging, rolling updates, resiliency concerns... the list is almost endless. Distributed systems benefit the business, not so much the developer.
 
 Until now.
 
 [![sbt to install microservices](http://img.youtube.com/vi/5qbX7UwuMYM/0.jpg)](http://www.youtube.com/watch?v=5qbX7UwuMYM)
 
-Whatever you think of [sbt](http://www.scala-sbt.org/), the primary build tool of [Lagom](http://www.lagomframework.com/documentation/1.0.x/java/Home.html), it is a powerful beast. As such we’ve made it do the heavy lifting of packaging, loading and running your entire Lagom system, including Cassandra, with just one simple command:
+Whatever you think of [sbt](http://www.scala-sbt.org/), the primary build tool of [Lagom](http://www.lagomframework.com/documentation/1.0.x/java/Home.html), it is a powerful beast. As such we've made it do the heavy lifting of packaging, loading and running your entire Lagom system, including Cassandra, with just one simple command:
 
 
 ```
 sbt> install
 ```
 
-This “install” command will introspect your project and its sub-projects, generate configuration, package everything up, load it into a local [ConductR](http://conductr.lightbend.com/docs/1.1.x/Home) cluster and then run it all.
+This "install" command will introspect your project and its sub-projects, generate configuration, package everything up, load it into a local [ConductR](http://conductr.lightbend.com/docs/1.1.x/Home) cluster and then run it all.
 *Just. One. Command.*
 Try doing that with your >insert favourite build tool here<!
 
@@ -30,6 +30,6 @@ Lower level commands also remain available so that you can package, load and run
 
 Lagom is aimed at making the developer productive when developing microservices. The ConductR integration now carries that same goal through to production.
 
-Please watch the 8 minute video for a comprehensive demonstration, and be sure to [visit the “Lagom for production” documentation](http://www.lagomframework.com/documentation/1.0.x/java/ConductR.html) in order to keep up to date with your production options. While we aim for Lagom to run with your favourite orchestration tool, we think you’ll find the build integration for ConductR hard to beat. Finally, you can focus on your business problem, and not the infrastructure to support it in production.
+Please watch the 8 minute video for a comprehensive demonstration, and be sure to [visit the "Lagom for production" documentation](http://www.lagomframework.com/documentation/1.0.x/java/ConductR.html) in order to keep up to date with your production options. While we aim for Lagom to run with your favourite orchestration tool, we think you'll find the build integration for ConductR hard to beat. Finally, you can focus on your business problem, and not the infrastructure to support it in production.
 
 Enjoy!

--- a/src/main/scala/com/lightbend/lagom/docs/Blog.scala
+++ b/src/main/scala/com/lightbend/lagom/docs/Blog.scala
@@ -1,8 +1,10 @@
 package com.lightbend.lagom.docs
 
-import java.io.{File, FileInputStream}
+import java.io.{ File, FileInputStream, IOException }
 
 import org.joda.time.DateTime
+
+import scala.util.control.NonFatal
 
 object Blog {
 
@@ -14,6 +16,8 @@ object Blog {
       val stream = new FileInputStream(file)
       try {
         BlogMetaDataParser.parsePostFrontMatter(stream, file.getName.dropRight(3))
+      } catch {
+        case NonFatal(e) => throw new IOException(s"Unable to parse ${file.getName}", e)
       } finally {
         stream.close()
       }

--- a/src/main/scala/com/lightbend/lagom/docs/BlogMetaDataParser.scala
+++ b/src/main/scala/com/lightbend/lagom/docs/BlogMetaDataParser.scala
@@ -2,6 +2,7 @@ package com.lightbend.lagom.docs
 
 import java.io.InputStream
 import java.net.URL
+import java.nio.charset.Charset
 
 import org.joda.time.DateTime
 
@@ -9,17 +10,19 @@ import scala.reflect.ClassTag
 import play.api.Logger
 import java.util.Date
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{ Json, Reads }
 
 import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
-import scala.io.Source
+import scala.io.{ Codec, Source }
 
 object BlogMetaDataParser {
 
   private implicit class IteratorOps[T](i: Iterator[T]) {
     def nextOption = if (i.hasNext) Option(i.next()) else None
   }
+
+  private implicit val codec = Codec(Charset.forName("US-ASCII"))
 
   private val gitHubCache = TrieMap.empty[String, GitHubUser]
 


### PR DESCRIPTION
This avoids problems parsing UTF-8 characters on Windows and fixes #39.

Also improves the error reporting for blog metadata parsing failures to include the filename in the error output.

Finally, it strips offending characters from the problematic post.

Our Markdown renderer translates straight quotes to curly quotes and triple dots to ellipses anyway, so you can't tell the difference.