### PR TITLE
Support no-file path navigation in local execution

### DIFF
--- a/project/SimpleHTTPServer.scala
+++ b/project/SimpleHTTPServer.scala
@@ -1,4 +1,4 @@
-import java.io.{ Closeable, File }
+import java.io.{Closeable, File}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -20,9 +20,22 @@ class SimpleHTTPServer(webDirectory: File, port: Int) extends Closeable {
   // needed for the future flatMap/onComplete in the end
   private implicit val executionContext = system.dispatcher
 
-  private val route = pathPrefix("") {
-    getFromDirectory(webDirectory.getAbsolutePath) ~ getFromFile(new File(webDirectory, "index.html"))
-  }
+  private val route =
+  // TODO: this needs improving. IT'd be good to have a generic fallback to serving 'index.html' from the
+  // appropriate folder anytime the path in the request leaves the last segment (filename) blank.
+    pathPrefix("documentation") {
+      pathEndOrSingleSlash {
+        getFromFile(new File(new File(webDirectory, "documentation"), "index.html"))
+      }
+    } ~
+      pathPrefix("blog") {
+        pathEndOrSingleSlash {
+          getFromFile(new File(new File(webDirectory, "blog"), "index.html"))
+        }
+      } ~
+      getFromDirectory(webDirectory.getAbsolutePath) ~
+      getFromFile(new File(webDirectory, "index.html"))
+
 
   val bindingFuture: Future[ServerBinding] = Http().bindAndHandle(route, "localhost", port)
 


### PR DESCRIPTION
This adds support to serve one-folder-deep paths that won't include a filename (e.g. `/docs`) with a fallback to serving `index.html`.

Fixes #54 and also serves `/blog` (without trailing slash) which is also used in the site..