### PR TITLE
Reduce real estate used by versions. Adds community content

### DIFF
--- a/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
+++ b/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
@@ -40,6 +40,23 @@ object DocumentationGenerator extends App {
     VersionSummary("1.0.x", s"Lagom 1.0.0")
   )
 
+  val communityContents = Seq(
+//    CommunityContent("title", "href", "hrefTitle"),
+    CommunityContent("Guide to Reactive Microservices Using Lagom Framework",
+      "http://www.baeldung.com/lagom-reactive-microservices",
+      "Baeldung"),
+    CommunityContent("CQRS and Event Sourcing with Lagom",
+      "https://blog.codecentric.de/en/2017/02/cqrs-event-sourcing-lagom/",
+      "codecentric Blog"),
+    CommunityContent("Lagom 1.2: What's New?",
+      "https://ordina-jworks.github.io/microservices/2017/02/01/Lagom-1-2.html",
+      "JWORKS TECH BLOG"),
+    CommunityContent("Run a Lagom service standalone with Zookeeper",
+      "https://thecoderwriter.wordpress.com/2016/09/24/run-a-lagom-service-standalone-with-zookeeper/",
+      "Coder's IO")
+
+  )
+
   // Set this to Some("your-github-account-name") if you want to deploy the docs to the gh-pages of your own fork
   // of the repo
   val gitHubAccount: Option[String] = None
@@ -268,7 +285,7 @@ object DocumentationGenerator extends App {
   }
 
   val generated = templatePages.map((generatePage _).tupled) ++
-    Seq(savePage("documentation/index.html", html.documentationIndex(stableVersions, previewVersions, oldVersions, versions))) ++
+    Seq(savePage("documentation/index.html", html.documentationIndex(stableVersions, previewVersions, oldVersions, versions, communityContents))) ++
     versions.map { version =>
       savePage(s"documentation/${version.name}/index.html", html.documentationVersionIndex(version), includeInSitemap = false)
     } ++
@@ -320,6 +337,8 @@ case class LagomContext(baseUrl: String, path: String, currentLagomVersion: Stri
                         blogSummary: BlogSummary, assetFingerPrint: String)
 
 case class VersionSummary(name: String, title: String)
+
+case class CommunityContent(description:String, href:String, hrefTitle:String)
 
 case class Version(name: String, languages: Seq[LanguageVersion]) {
   def versionFor(language: String): Option[LanguageVersion] = languages.find(_.language == language)

--- a/src/main/twirl/com/lightbend/lagom/docs/documentationIndex.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentationIndex.scala.html
@@ -1,24 +1,29 @@
 @import com.lightbend.lagom.docs.VersionSummary
+@import com.lightbend.lagom.docs.CommunityContent
 @import com.lightbend.lagom.docs.Version
 @import com.lightbend.lagom.docs.LagomContext
 
-@(stableVersions: Seq[VersionSummary], previewVersions: Seq[VersionSummary], oldVersions: Seq[VersionSummary], versions: Seq[Version])(implicit ctx: LagomContext)
+@(stableVersions: Seq[VersionSummary], previewVersions: Seq[VersionSummary], oldVersions: Seq[VersionSummary], versions: Seq[Version], communityContents: Seq[CommunityContent])(implicit ctx: LagomContext)
 
 @toTitleCase(s: String) = {@s.head.toUpper@s.tail}
 
 @renderVersion(summary: VersionSummary) = {
-    <h2>@summary.title</h2>
-
+    <h3>@summary.title</h3>
     @for(version <- versions.find(_.name == summary.name)) {
+        <ul>
         @for(lang <- version.languages) {
-            <h3>@toTitleCase(lang.language)</h3>
-
-            <ul>
-                <li><a href="@ctx.path/documentation/@version.name/@lang.language/Home.html">Reference manual</a></li>
-                <li><a href="@ctx.path/documentation/@version.name/@lang.language/api/index.html">API docs</a></li>
-            </ul>
-        }
+            <li>@toTitleCase(lang.language): <a href="@ctx.path/documentation/@version.name/@lang.language/Home.html">Reference manual</a> and <a href="@ctx.path/documentation/@version.name/@lang.language/api/index.html">API docs</a>.</li>
+            }
+        </ul>
     }
+}
+
+@renderContent(communityContents: Seq[CommunityContent]) = {
+    <ul>
+    @for(cc <- communityContents) {
+        <li>@{cc.description} (<a href="@cc.href">@cc.hrefTitle</a>)</li>
+    }
+    </ul>
 }
 
 @page("Lagom documentation") {
@@ -55,6 +60,17 @@
         @for(oldVersion <- oldVersions) {
             @renderVersion(oldVersion)
         }
+    }
+
+    @if(communityContents) {
+        <h1>Community Content</h1>
+
+        <p>
+            Blog posts, webinars, tutorials and other content provided by the community.
+        </p>
+
+        @renderContent(communityContents)
+
     }
 
 


### PR DESCRIPTION
Reviews [Docs index](https://www.lagomframework.com/documentation/) to reduce the real estate used by versions/lang/api-docs and add a list of community provided contents.

Samples:

Before - 


<img width="595" alt="screen shot 2017-04-19 at 10 53 10" src="https://cloud.githubusercontent.com/assets/762126/25171727/0fb11d52-24ef-11e7-879c-fdf7dc992017.png">


After - 

<img width="693" alt="screen shot 2017-04-19 at 10 52 56" src="https://cloud.githubusercontent.com/assets/762126/25171738/17c9af04-24ef-11e7-911a-69de0213dc96.png">
