### PR TITLE
Update "Typesafe" to "Lightbend"

### DIFF
--- a/src/main/markdown/contributing.md
+++ b/src/main/markdown/contributing.md
@@ -15,7 +15,7 @@ When the above guidelines are not followed, a Lagom integrator may close the iss
 
 ### Prerequisites
 
-Before making a contribution, it is important to make sure that the change you wish to make and the approach you wish to take will likely be accepted, otherwise you may end up doing a lot of work for nothing.  If the change is only small, for example, if it's a documentation change or a simple bugfix, then it's likely to be accepted with no prior discussion.  However, new features, or bigger refactorings should first be discussed in the [contributors](https://gitter.im/lagom/contributors).  Additionally, any issues with the [community label](https://github.com/lagom/lagom/labels/community) have been agreed to be a change that will likely be accepted.
+Before making a contribution, it is important to make sure that the change you wish to make and the approach you wish to take will likely be accepted, otherwise you may end up doing a lot of work for nothing.  If the change is only small, for example, if it's a documentation change or a simple bug fix, then it's likely to be accepted with no prior discussion.  However, new features, or bigger refactorings should first be discussed in the [contributors](https://gitter.im/lagom/contributors).  Additionally, any issues with the [community label](https://github.com/lagom/lagom/labels/community) have been agreed to be a change that will likely be accepted.
 
 ### Procedure
 
@@ -51,8 +51,8 @@ Generally, all bug fixes, improvements and new features will go to the master br
 
 * The change only affects the documentation
 * The change fixes a regression that was introduced in a previous stable release from that branch
-* The change fixes a bug that impacts significant number of members of the open source community with no simple work arounds available
-* Any other reason that Typesafe deems appropriate
+* The change fixes a bug that impacts significant number of members of the open source community with no simple workarounds available
+* Any other reason that Lightbend deems appropriate
 
 All backports and other commits to stable branches, in addition to satisfying the regular contributor guidelines, must also be binary and source compatible with previous releases on that branch.  The only exception to this is if a serious bug is impossible to fix without breaking the API, for example, a particular feature is not possible to use due to flaws in the API.
 


### PR DESCRIPTION
Also fix a few minor typos picked up by the IntelliJ spelling checker.