### PR TITLE
Added 404 page

### DIFF
--- a/project/SimpleHTTPServer.scala
+++ b/project/SimpleHTTPServer.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.RouteResult.Complete
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 
@@ -20,12 +21,19 @@ class SimpleHTTPServer(webDirectory: File, port: Int) extends Closeable {
   // needed for the future flatMap/onComplete in the end
   private implicit val executionContext = system.dispatcher
 
+  private val route404 = getFromFile(new File(webDirectory, "404.html"))
+    .andThen(_.map {
+      case Complete(response) => Complete(response.copy(status = 404))
+      case other => other
+    })
+
   private val route =
     getFromDirectory(webDirectory.getAbsolutePath) ~
       pathPrefix(Segments) { folderNameSeq =>
         val absoluteFolder = folderNameSeq.foldLeft(webDirectory)((acc, subfolder) => new File(acc, subfolder))
         getFromFile(new File(absoluteFolder, "index.html"))
-      }
+      } ~ route404
+
 
   val bindingFuture: Future[ServerBinding] = Http().bindAndHandle(route, "localhost", port)
 

--- a/src/main/markdown/404.md
+++ b/src/main/markdown/404.md
@@ -1,0 +1,3 @@
+# 404 - Not Found
+
+The Lagom website does not contain too many pages, nor does it contain too few pages. It contains just the right amount of pages. The page you have requested is not one of them.


### PR DESCRIPTION
GitHub pages will serve a page called 404.html if it exists when pages aren't found. This adds that page, and also adds support to the built in dev server to serve it.