### PR TITLE
Change OSX to macOS.

### DIFF
--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
@@ -48,7 +48,7 @@
                             extracted the project into a directory named <code>my-project</code>:
                             </p>
                             <ul>
-                              <li>In an macOS or Linux shell: <pre class="prettyprint"><code class="language-sh">cd my-project/lagom-java-sbt</code></pre></li>
+                              <li>In a macOS or Linux shell: <pre class="prettyprint"><code class="language-sh">cd my-project/lagom-java-sbt</code></pre></li>
                               <li>In a Windows shell: <pre class="prettyprint"><code class="language-sh">cd my-project\lagom-java-sbt</code></pre></li>
                           </ul></li>
                           <li><p>Start sbt and the Lagom development environment:

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
@@ -41,14 +41,14 @@
                       <p>After downloading the compressed file from Tech Hub, follow these steps:</p>
                       <ol>
                         <li><p>Extract the compressed file to a directory of your choice.</p>
-                          <p>Note: On OSX, if you unzip using Archiver, you also have to make the sbt files executable:</p>
+                          <p>Note: On macOS, if you unzip using Archiver, you also have to make the sbt files executable:</p>
                           <pre class="prettyprint"><code class="language-sh">chmod u+x ./sbt </code></pre>
                           <pre class="prettyprint"><code class="language-sh">chmod u+x ./sbt-dist/bin/sbt</code></pre></li>
                         <li><p>In a shell, change into the top-level directory of the project, <code>lagom-java-sbt</code>. For example, if you
                             extracted the project into a directory named <code>my-project</code>:
                             </p>
                             <ul>
-                              <li>In an OSX or Linux shell: <pre class="prettyprint"><code class="language-sh">cd my-project/lagom-java-sbt</code></pre></li>
+                              <li>In an macOS or Linux shell: <pre class="prettyprint"><code class="language-sh">cd my-project/lagom-java-sbt</code></pre></li>
                               <li>In a Windows shell: <pre class="prettyprint"><code class="language-sh">cd my-project\lagom-java-sbt</code></pre></li>
                           </ul></li>
                           <li><p>Start sbt and the Lagom development environment:

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedscala.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedscala.scala.html
@@ -55,7 +55,7 @@
                   <p>Once you've downloaded a compressed file from Tech Hub, follow these steps:</p>
                   <ol>
                   <li><p>Extract the compressed file to a directory of your choice.</p>
-                  <p>Note: On OSX, if you unzip using Archiver, you also have to make the sbt files executable:</p>
+                  <p>Note: On macOS, if you unzip using Archiver, you also have to make the sbt files executable:</p>
                   <pre class="prettyprint"><code class="language-sh">chmod u+x ./sbt </code></pre>
                   <pre class="prettyprint"><code class="language-sh">chmod u+x ./sbt-dist/bin/sbt</code></pre>
 


### PR DESCRIPTION
@TimMoore, I noticed the missing space in OSX on the two getting started pages I had revised, but then I found that Apple has been using macOS instead of OS X since 2016. Do we need to use both, since some users might have the older OS? or do you think macOS is sufficient? If it is, please merge this change to fix #88.