### PR TITLE
Change hyperlink of community label and add newbie label.

### DIFF
--- a/src/main/twirl/com/lightbend/lagom/docs/getinvolved.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getinvolved.scala.html
@@ -47,7 +47,8 @@
 
         <p>
             You're welcome to work on any feature you like — Lagom is open source after all! — but if you'd like some good ideas, look for issues tagged with the
-            <a href="//github.com/lagom/lagom/issues?labels=community">community</a> label.
+            <a href="//github.com/lagom/lagom/labels/help%3Anewbie">newbie</a> label and
+            <a href="//github.com/lagom/lagom/labels/help%3Acommunity">community</a> label.
             These issues are ready and waiting for volunteers to pick them up.
         </p>
     </div>


### PR DESCRIPTION
Changed community label from "[community](https://github.com/lagom/lagom/issues?q=label%3Acommunity)" to "[help:community](https://github.com/lagom/lagom/labels/help%3Acommunity)" and added new hyperlink of [newbie](https://github.com/lagom/lagom/labels/help%3Anewbie) label. I think it would be much easier for new contributors.   