### PR TITLE
Increase version of preview to 1.4.0-M2

### DIFF
--- a/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
+++ b/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
@@ -33,7 +33,7 @@ object DocumentationGenerator extends App {
   )
 
   val previewVersions = Seq(
-    VersionSummary("1.4.x", s"Lagom 1.4.0-M1 (preview)")
+    VersionSummary("1.4.x", s"Lagom 1.4.0-M2 (preview)")
   )
 
   val oldVersions = Seq(


### PR DESCRIPTION
In my previous PR I forgot to update the link in the Docs index to `1.4.0-M2`