### PR TITLE
Capitalizes contributor name despite his profile on Github

### DIFF
--- a/src/blog/lagom-1-4-0-M2.md
+++ b/src/blog/lagom-1-4-0-M2.md
@@ -29,4 +29,4 @@ The Lagom 1.4.x series is not focused on providing new, big features. Instead, i
 
 ### Community Contributions
 
-This release includes great contributions from the community. Thanks Wayne Wang, Elijah Rippeth, Yuliana Apaza and surya prakash singh. Special thanks if this was your [first contribution](/get-involved.html).
+This release includes great contributions from the community. Thanks Wayne Wang, Elijah Rippeth, Yuliana Apaza and Surya Prakash Singh. Special thanks if this was your [first contribution](/get-involved.html).


### PR DESCRIPTION
After discussing with @oliver we decided that despite the user profile on GH is all lowercase we'd post thanks with Capitalized names/surnames.