### PR TITLE
Use https links to Tech Hub

### DIFF
--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjavamaven.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjavamaven.scala.html
@@ -37,7 +37,7 @@
                 <h2>Download the project from Tech Hub</h2>
                       <p>Follow these steps to download a project created from the template:</p>
                       <ol>
-                        <li><p>Open the <a class="" href="http://developer.lightbend.com/start/?group=lagom&project=lagom-java-maven" target="_blank">Tech Hub Project Starter</a>.</p></li>
+                        <li><p>Open the <a class="" href="https://developer.lightbend.com/start/?group=lagom&project=lagom-java-maven" target="_blank">Tech Hub Project Starter</a>.</p></li>
                         <li><p>Click <b>CREATE A PROJECT FOR ME</b>.</p>
                             <p>The browser downloads a compressed project.</p>
                         </li>

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjavamaven.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjavamaven.scala.html
@@ -37,7 +37,7 @@
                 <h2>Download the project from Tech Hub</h2>
                       <p>Follow these steps to download a project created from the template:</p>
                       <ol>
-                        <li><p>Open the <a class="" href="https://developer.lightbend.com/start/?group=lagom&project=lagom-java-maven" target="_blank">Tech Hub Project Starter</a>.</p></li>
+                        <li><p>Open the <a class="" href="https://developer.lightbend.com/start/?group=lagom&amp;project=lagom-java-maven" target="_blank">Tech Hub Project Starter</a>.</p></li>
                         <li><p>Click <b>CREATE A PROJECT FOR ME</b>.</p>
                             <p>The browser downloads a compressed project.</p>
                         </li>

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
@@ -32,7 +32,7 @@
               <h2>Download the project from Tech Hub</h2>
                     <p>Follow these steps to download a project created from the template:</p>
                     <ol>
-                      <li><p>Open the <a class="" href="http://developer.lightbend.com/start/?group=lagom&project=lagom-java-sbt" target="_blank">Tech Hub Project Starter</a>.</p></li>
+                      <li><p>Open the <a class="" href="https://developer.lightbend.com/start/?group=lagom&project=lagom-java-sbt" target="_blank">Tech Hub Project Starter</a>.</p></li>
                       <li><p>Click <b>CREATE A PROJECT FOR ME</b>.</p>
                           <p>The browser downloads a compressed project.</p>
                       </li>

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedjavasbt.scala.html
@@ -32,7 +32,7 @@
               <h2>Download the project from Tech Hub</h2>
                     <p>Follow these steps to download a project created from the template:</p>
                     <ol>
-                      <li><p>Open the <a class="" href="https://developer.lightbend.com/start/?group=lagom&project=lagom-java-sbt" target="_blank">Tech Hub Project Starter</a>.</p></li>
+                      <li><p>Open the <a class="" href="https://developer.lightbend.com/start/?group=lagom&amp;project=lagom-java-sbt" target="_blank">Tech Hub Project Starter</a>.</p></li>
                       <li><p>Click <b>CREATE A PROJECT FOR ME</b>.</p>
                           <p>The browser downloads a compressed project.</p>
                       </li>

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedscala.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedscala.scala.html
@@ -44,7 +44,7 @@
 
                   <ol>
                   <li><p>Open the <a class=""
-                  href="https://developer.lightbend.com/start/?group=lagom&project=lagom-scala-sbt"
+                  href="https://developer.lightbend.com/start/?group=lagom&amp;project=lagom-scala-sbt"
                   target="_blank">Tech Hub Project Starter</a>.</p></li>
 
                   <li><p>Click <b>CREATE A PROJECT FOR ME</b>.</p>

--- a/src/main/twirl/com/lightbend/lagom/docs/getstartedscala.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getstartedscala.scala.html
@@ -44,7 +44,7 @@
 
                   <ol>
                   <li><p>Open the <a class=""
-                  href="http://developer.lightbend.com/start/?group=lagom&project=lagom-scala-sbt"
+                  href="https://developer.lightbend.com/start/?group=lagom&project=lagom-scala-sbt"
                   target="_blank">Tech Hub Project Starter</a>.</p></li>
 
                   <li><p>Click <b>CREATE A PROJECT FOR ME</b>.</p>


### PR DESCRIPTION
There is currently a buggy redirect from http to https that changes the URL parameters and causes the resulting page to be empty.