### PR TITLE
set 1.4.0-RC1 as main version

### DIFF
--- a/src/blog/lagom-1-4-0-RC1.md
+++ b/src/blog/lagom-1-4-0-RC1.md
@@ -27,7 +27,7 @@ See the [full list of changes](https://github.com/lagom/lagom/compare/1.4.0-M3..
 * Upgraded to Akka HTTP 10.0.11 
 * Upgraded to Play 2.6.10
 * Upgraded to akka-persistence-jdbc to 3.1.0
-* Akka-HTTP as default backend
+* Akka HTTP as default backend
 * maxFrameLength config parameter for WebSocketClient
 
  

--- a/src/main/markdown/changelog.md
+++ b/src/main/markdown/changelog.md
@@ -1,5 +1,29 @@
 # Lagom Change Log
 
+## Lagom 1.4.0-RC1
+
+*Released 22 December 2017*
+
+* [1151](https://github.com/lagom/lagom/issues/1151) Set four-space indent for XML files (Tim Moore)
+* [1109](https://github.com/lagom/lagom/issues/1109) Ensure Akka cluster is left gracefully (Ignasi Marimon-Clos)
+* [1147](https://github.com/lagom/lagom/issues/1147) Maven Dependency POM and Archetype supporting 2.11 and 2.12 (Renato Cavalcanti)
+* [1146](https://github.com/lagom/lagom/issues/1146) Update Scala 2.11 to 2.11.12 (Tim Moore)
+* [1148](https://github.com/lagom/lagom/issues/1148) Update ConductR guides (Tim Moore)
+* [1141](https://github.com/lagom/lagom/issues/1141) Clarify sbt instructions for running a single service (Renato Cavalcanti)
+* [1145](https://github.com/lagom/lagom/issues/1145) Update play-file-watch to 1.1.7 (Tim Moore)
+* [1143](https://github.com/lagom/lagom/issues/1143) Update akka-persistence-jdbc to 3.1.0 (Renato Cavalcanti)
+* [1140](https://github.com/lagom/lagom/issues/1140) Manage JNDI lifecycle (Tim Moore)
+* [1054](https://github.com/lagom/lagom/issues/1054) Sets Akka-HTTP as default backend (Ignasi Marimon-Clos)
+* [1134](https://github.com/lagom/lagom/issues/1134) Bumps Akka 2.5.8, AkkaHttp 10.0.11 and Play 2.6.9 (Ignasi Marimon-Clos)
+* [1051](https://github.com/lagom/lagom/issues/1051) Fixed invalid type signature on PersistentEntityRef.ask (James Roper)
+* [1128](https://github.com/lagom/lagom/issues/1128) fixes formatting (Renato Cavalcanti)
+* [1125](https://github.com/lagom/lagom/issues/1125) Overrides defaults for host-connection-pool (Ignasi Marimon-Clos)
+* [1127](https://github.com/lagom/lagom/issues/1127) typo on bonecp config (Renato Cavalcanti)
+* [1112](https://github.com/lagom/lagom/issues/1112) Added a check to warn about slow startup problems (Edmondo Porcu)
+* [1121](https://github.com/lagom/lagom/issues/1121) Introduces a JndiConfigurator that is run before SlickProvider creation (Renato Cavalcanti)
+* [1123](https://github.com/lagom/lagom/issues/1123) Update the 1.4 migration guide for 1.4.0-M3 (Tim Moore)
+* [1090](https://github.com/lagom/lagom/issues/1090) Add maxFrameLength config parameter for WebSocketClient (datalchemist)
+
 ## Lagom 1.4.0-M3
 
 *Released 30 November 2017*

--- a/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
+++ b/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
@@ -23,18 +23,17 @@ object DocumentationGenerator extends App {
    * CONFIGURATION
    */
   // Current documentation version
-  val currentDocsVersion = "1.3.x"
-  val currentLagomVersion = "1.3.10"
+  val currentDocsVersion = "1.4.x"
+  val currentLagomVersion = "1.4.0-RC1"
 
   // This impacts what gets displayed on the main documentation index.
   val stableVersions = Seq(
-    VersionSummary("1.3.x", s"Lagom $currentLagomVersion (current stable release)"),
-    VersionSummary("1.2.x", s"Lagom 1.2.3 (previous stable release)")
+    VersionSummary("1.4.x", s"Lagom $currentLagomVersion (current stable release candidate)"),
+    VersionSummary("1.3.x", s"Lagom 1.3.10 (current stable release)"),
+    VersionSummary("1.2.x", s"Lagom 1.2.3  (previous stable release)") 
   )
 
-  val previewVersions = Seq(
-    VersionSummary("1.4.x", s"Lagom 1.4.0-M3 (preview)")
-  )
+  val previewVersions = Seq.empty[VersionSummary]
 
   val oldVersions = Seq(
     VersionSummary("1.1.x", s"Lagom 1.1.0"),


### PR DESCRIPTION
We forgot to add 1.4.0-RC1 as main stable release. 

This PR do the swap, but it keeps 1.3.10 as "current stable" and 1.4.0-RC1 as "current stable RC"