### PR TITLE
Add a cross-project search input

### DIFF
--- a/src/main/assets/_documentation.styl
+++ b/src/main/assets/_documentation.styl
@@ -148,6 +148,19 @@ article
       .aa-cursor .algolia-docsearch-suggestion
         background: akka-blue-ltr
 
+  .play
+      .algolia-docsearch-suggestion
+        border-bottom-color play-green-dkr
+      .algolia-docsearch-suggestion--category-header
+        background-color play-green
+      .algolia-docsearch-suggestion--highlight
+        color: play-green
+      .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight
+        background-color: play-green-ltr
+      .aa-cursor .algolia-docsearch-suggestion--content
+        color: play-green-dkr
+      .aa-cursor .algolia-docsearch-suggestion
+        background: play-green-ltr
 
 .edit-source
   font-size 1em

--- a/src/main/assets/_documentation.styl
+++ b/src/main/assets/_documentation.styl
@@ -134,6 +134,21 @@ article
   .aa-cursor .algolia-docsearch-suggestion
     background: lgm-purple-ltr-ltr
 
+  .akka
+      .algolia-docsearch-suggestion
+        border-bottom-color akka-blue-dkr
+      .algolia-docsearch-suggestion--category-header
+        background-color akka-blue
+      .algolia-docsearch-suggestion--highlight
+        color: akka-blue
+      .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight
+        background-color: akka-blue-ltr
+      .aa-cursor .algolia-docsearch-suggestion--content
+        color: akka-blue-dkr
+      .aa-cursor .algolia-docsearch-suggestion
+        background: akka-blue-ltr
+
+
 .edit-source
   font-size 1em
   margin-top 40px

--- a/src/main/assets/_vars.styl
+++ b/src/main/assets/_vars.styl
@@ -8,6 +8,11 @@ akka-blue =          #1CA9CC
 akka-blue-dkr =      #0E5565
 akka-blue-ltr =      #74CAE0
 
+play-green =          #A0CE56
+play-green-dkr =      #50672B
+play-green-ltr =      #6AB2A2
+
+
 
 lb-slate =           #1c3b47
 lb-slate-dkr =       #152c35

--- a/src/main/assets/_vars.styl
+++ b/src/main/assets/_vars.styl
@@ -3,6 +3,12 @@ lgm-purple-dkr =     #421540
 lgm-purple-ltr =     #bf97c6
 lgm-purple-ltr-ltr = #d3b0d3
 
+
+akka-blue =          #1CA9CC
+akka-blue-dkr =      #0E5565
+akka-blue-ltr =      #74CAE0
+
+
 lb-slate =           #1c3b47
 lb-slate-dkr =       #152c35
 lb-slate-ltr =       #49626c

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -12,26 +12,16 @@
     @for(css <- context.resources.stylesheets) {<link rel="stylesheet" type="text/css" href="@css"/>
     }
 } { @* Footer *@
-    <script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
-    <script type="text/javascript"> docsearch({
-        apiKey: "77ef1e29e6bddfca861f7a42cc51725e",
-        indexName: "lagomframework",
-        inputSelector: "#docs-search",
-        algoliaOptions: {
-            facetFilters: ["version:@version", "language:@language"]
-        }
-    });
-    </script>
-
     <script type="text/javascript" src="//cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
     <script type="text/javascript" src="//cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>
         <!-- Cross-site search. This is using Algolia's autocomplete.js  -->
     <script>
             var clientLagom = algoliasearch('BH4D9OD16A', '77ef1e29e6bddfca861f7a42cc51725e');
-            var clientAkka = algoliasearch('BH4D9OD16A', '543bad5ad786495d9ccd445ed34ed082');
+            var clientAkka  = algoliasearch('BH4D9OD16A', '543bad5ad786495d9ccd445ed34ed082');
+            var clientPlay  = algoliasearch('BH4D9OD16A', 'a0b34e68c804cf96e76adcb02d47159b');
             var lagomIndex = clientLagom.initIndex('lagomframework');
-            var akkaIndex = clientAkka.initIndex('akka_io');
-            //initialize autocomplete on search input (ID selector must match)
+            var akkaIndex  = clientAkka.initIndex('akka_io');
+            var playIndex  = clientPlay.initIndex('playframework');
 
             var displayValue = function (suggestion, level) {
                 if (level === 0)
@@ -57,19 +47,15 @@
                     {
                         source: autocomplete.sources.hits(lagomIndex,
                                 {
-                                    hitsPerPage: 4,
+                                    hitsPerPage: 5,
                                     facetFilters: [
                                         'language:scala', // TODO: parameterize
                                         'version:current' ]
                                 }),
-                        //value to be displayed in input control after user's suggestion selection
-                        // displayKey: 'lvl0',
-                        //hash of templates used when rendering dataset
                         templates: {
                             header: '<span class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main algolia-docsearch-suggestion__secondary algolia-docsearch-suggestion--category-header ">Lagom Documentation</span>',
-                            //'suggestion' templating function used to render a single suggestion
                             suggestion: function(suggestion) {
-                                return  '        <div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
+                                return  '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
                                  '<div class="algolia-docsearch-suggestion--wrapper">' +
                                     '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
                                         '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
@@ -89,20 +75,46 @@
                     {
                         source: autocomplete.sources.hits(akkaIndex,
                                 {
-                                    hitsPerPage: 4,
+                                    hitsPerPage: 2,
                                     facetFilters: ['language:scala'] // TODO: parameterize
                                     // akka_io only indexes 'current'
                                 }),
-                        //value to be displayed in input control after user's suggestion selection
-                        // displayKey: 'lvl0',
-                        //hash of templates used when rendering dataset
                         templates: {
-                            // last item on the list must include the algolia footer
-                            footer: '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>',
                             header: '<span class="akka"><span class="algolia-docsearch-suggestion algolia-docsearch-suggestion--category-header ">Akka Documentation</span></span>',
                             //'suggestion' templating function used to render a single suggestion
                             suggestion: function(suggestion) {
                                 return '<span class="akka">'+
+                                '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
+                                        '<div class="algolia-docsearch-suggestion--wrapper">' +
+                                        '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
+                                        '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
+                                        '</div>' +
+                                        '<div class="algolia-docsearch-suggestion--content">' +
+                                        '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
+                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
+                                        displaySnippet(suggestion) +
+                                        '</div>' +
+                                        '</div>' +
+                                        '</div>' +
+                                        '</span>';
+                            }
+                        }
+                    }
+                    ,
+                    // configure Play's index
+                    {
+                        source: autocomplete.sources.hits(playIndex,
+                                {
+                                    hitsPerPage: 2,
+                                    facetFilters: ['version:2.6.x', 'tags:en']
+                                }),
+                        templates: {
+                            // last item on the list must include the algolia footer
+                            footer: '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>',
+                            header: '<span class="play"><span class="algolia-docsearch-suggestion algolia-docsearch-suggestion--category-header ">Play Documentation</span></span>',
+                            //'suggestion' templating function used to render a single suggestion
+                            suggestion: function(suggestion) {
+                                return '<span class="play">'+
                                 '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
                                         '<div class="algolia-docsearch-suggestion--wrapper">' +
                                         '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
@@ -181,9 +193,7 @@
             <aside class="small-12 large-4 columns">
                 <nav class="side-menu">
 
-                    <input type="search" id="cross-docs-search" placeholder="Search other projects..." />
-
-                    <input type="text" id="docs-search" placeholder="Search"/>
+                    <input type="search" id="cross-docs-search" placeholder="Search..." />
 
                     <label for="docs-version">Version:</label>
                     <select id="docs-version">

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -42,6 +42,13 @@
                     return displayValue(suggestion, level - 1) ;
                 }
             };
+            var displaySnippet = function (suggestion) {
+              if(typeof suggestion._snippetResult !== 'undefined'){
+                return '<div class="algolia-docsearch-suggestion--text">' + suggestion._snippetResult.content.value + '</div>'
+              } else {
+                return ''
+              }
+            }
 
             autocomplete('#cross-docs-search',
                     { hint: false },
@@ -69,7 +76,8 @@
                                     '</div>' +
                                     '<div class="algolia-docsearch-suggestion--content">' +
                                         '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</span></div>' +
+                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
+                                        displaySnippet(suggestion) +
                                     '</div>' +
                                 '</div>'+
                               '</div>';
@@ -102,7 +110,8 @@
                                         '</div>' +
                                         '<div class="algolia-docsearch-suggestion--content">' +
                                         '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</span></div>' +
+                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
+                                        displaySnippet(suggestion) +
                                         '</div>' +
                                         '</div>' +
                                         '</div>' +

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -22,6 +22,69 @@
         }
     });
     </script>
+
+    <script type="text/javascript" src="//cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>
+        <!-- Cross-site search. This is using Algolia's autocomplete.js  -->
+    <script>
+            var clientLagom = algoliasearch('BH4D9OD16A', '77ef1e29e6bddfca861f7a42cc51725e');
+            var clientAkka = algoliasearch('BH4D9OD16A', '543bad5ad786495d9ccd445ed34ed082');
+            var lagomIndex = clientLagom.initIndex('lagomframework');
+            var akkaIndex = clientAkka.initIndex('akka_io');
+            //initialize autocomplete on search input (ID selector must match)
+            autocomplete('#aa-cross-docs-search-input',
+                    { hint: false },
+                    [
+
+                    // configure Lagom's index
+                    {
+                        source: autocomplete.sources.hits(lagomIndex,
+                                {
+                                    hitsPerPage: 4,
+                                    facetFilters: ['language:scala', 'version:current' ]
+                                }),
+                        //value to be displayed in input control after user's suggestion selection
+                        // displayKey: 'lvl0',
+                        //hash of templates used when rendering dataset
+                        templates: {
+                            header: '<div class="aa-suggestions-category">Lagom</div>',
+                            //'suggestion' templating function used to render a single suggestion
+                            suggestion: function(suggestion) {
+                                return '<span>' +
+                                        suggestion._highlightResult.hierarchy.lvl0.value + '</span><span>' +
+                                        suggestion._highlightResult.hierarchy.lvl1.value + '</span>';
+                            }
+                        }
+                    }
+                    ,
+                    // configure Akka's index
+                    {
+                        source: autocomplete.sources.hits(akkaIndex,
+                                {
+                                    hitsPerPage: 4,
+                                    facetFilters: ['language:scala']
+                                    // akka_io only indexes 'current'
+                                }),
+                        //value to be displayed in input control after user's suggestion selection
+                        // displayKey: 'lvl0',
+                        //hash of templates used when rendering dataset
+                        templates: {
+                            header: '<div class="aa-suggestions-category">Akka</div>',
+                            //'suggestion' templating function used to render a single suggestion
+                            suggestion: function(suggestion) {
+                                return '<span>' +
+                                        suggestion._highlightResult.hierarchy.lvl0.value + '</span><span>' +
+                                        suggestion._highlightResult.hierarchy.lvl1.value + '</span>';
+                            }
+                        }
+                    }
+
+                    ]
+                    );
+    </script>
+
+
+
     @for(script <- context.resources.scripts) {<script type="text/javascript" src="@script"></script>
     }
 } {  @* Body *@
@@ -75,6 +138,16 @@
             </div>
             <aside class="small-12 large-4 columns">
                 <nav class="side-menu">
+
+
+                    <div class="aa-input-container" id="aa-input-container">
+                        <input type="search" id="aa-cross-docs-search-input" class="aa-input-search" placeholder="Search other projects..." name="search" autocomplete="off" />
+                        <svg class="aa-input-icon" viewBox="654 -372 1664 1664">
+                            <path d="M1806,332c0-123.3-43.8-228.8-131.5-316.5C1586.8-72.2,1481.3-116,1358-116s-228.8,43.8-316.5,131.5  C953.8,103.2,910,208.7,910,332s43.8,228.8,131.5,316.5C1129.2,736.2,1234.7,780,1358,780s228.8-43.8,316.5-131.5  C1762.2,560.8,1806,455.3,1806,332z M2318,1164c0,34.7-12.7,64.7-38,90s-55.3,38-90,38c-36,0-66-12.7-90-38l-343-342  c-119.3,82.7-252.3,124-399,124c-95.3,0-186.5-18.5-273.5-55.5s-162-87-225-150s-113-138-150-225S654,427.3,654,332  s18.5-186.5,55.5-273.5s87-162,150-225s138-113,225-150S1262.7-372,1358-372s186.5,18.5,273.5,55.5s162,87,225,150s113,138,150,225  S2062,236.7,2062,332c0,146.7-41.3,279.7-124,399l343,343C2305.7,1098.7,2318,1128.7,2318,1164z" />
+                        </svg>
+                    </div>
+
+
 
                     <input type="text" id="docs-search" placeholder="Search"/>
 

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -9,7 +9,8 @@
 
 @main(Some(context.title), canonical) { @* Header *@
     <link rel="stylesheet" href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
-    @for(css <- context.resources.stylesheets) {<link rel="stylesheet" type="text/css" href="@css"/>
+    @for(css <- context.resources.stylesheets) {
+        <link rel="stylesheet" type="text/css" href="@css"/>
     }
 } { @* Footer *@
     <script type="text/javascript" src="//cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
@@ -17,11 +18,11 @@
         <!-- Cross-site search. This is using Algolia's autocomplete.js  -->
     <script>
             var clientLagom = algoliasearch('BH4D9OD16A', '77ef1e29e6bddfca861f7a42cc51725e');
-            var clientAkka  = algoliasearch('BH4D9OD16A', '543bad5ad786495d9ccd445ed34ed082');
-            var clientPlay  = algoliasearch('BH4D9OD16A', 'a0b34e68c804cf96e76adcb02d47159b');
+            var clientAkka = algoliasearch('BH4D9OD16A', '543bad5ad786495d9ccd445ed34ed082');
+            var clientPlay = algoliasearch('BH4D9OD16A', 'a0b34e68c804cf96e76adcb02d47159b');
             var lagomIndex = clientLagom.initIndex('lagomframework');
-            var akkaIndex  = clientAkka.initIndex('akka_io');
-            var playIndex  = clientPlay.initIndex('playframework');
+            var akkaIndex = clientAkka.initIndex('akka_io');
+            var playIndex = clientPlay.initIndex('playframework');
 
             var displayValue = function (suggestion, level) {
                 if (level === 0)
@@ -33,77 +34,89 @@
                 }
             };
             var displaySnippet = function (suggestion) {
-              if(typeof suggestion._snippetResult !== 'undefined'){
-                return '<div class="algolia-docsearch-suggestion--text">' + suggestion._snippetResult.content.value + '</div>'
-              } else {
-                return ''
-              }
+                if (typeof suggestion._snippetResult !== 'undefined') {
+                    return '<div class="algolia-docsearch-suggestion--text">' + suggestion._snippetResult.content.value + '</div>'
+                } else {
+                    return ''
+                }
             }
 
-            var wrap = function(content, wrapper){
-              if(typeof wrapper !== 'undefined'){
-                return '<span class='+wrapper+'>' + content + '</span>';
-              } else {
-                return content;
-              }
+            var wrap = function (content, wrapper) {
+                if (typeof wrapper !== 'undefined') {
+                    return '<span class=' + wrapper + '>' + content + '</span>';
+                } else {
+                    return content;
+                }
             }
 
-            var buildIndexSettings = function(_indexObj, _hitsPerPage, _faceFilters, title, useFooter, wrapper) {
-              var _header = wrap('<span class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main algolia-docsearch-suggestion__secondary algolia-docsearch-suggestion--category-header ">'+title+'</span>', wrapper);
-              var _templates =  {
-                                    header: _header,
-                                    suggestion: function(suggestion) {
-                                        var suggestionHtml = '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
-                                         '<div class="algolia-docsearch-suggestion--wrapper">' +
-                                            '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
-                                                '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
-                                            '</div>' +
-                                            '<div class="algolia-docsearch-suggestion--content">' +
-                                                '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
-                                                '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
-                                                displaySnippet(suggestion) +
-                                            '</div>' +
-                                        '</div>'+
-                                      '</div>';
-                                      return wrap(suggestionHtml, wrapper)
-                                    }
-                                };
-              if(useFooter){
-                _templates['footer'] = '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>';
-              }
+            var buildIndexSettings = function (_indexObj, _hitsPerPage, _faceFilters, title, useFooter, wrapper) {
+                var _header = wrap('<span class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main algolia-docsearch-suggestion__secondary algolia-docsearch-suggestion--category-header ">' + title + '</span>', wrapper);
+                var _templates = {
+                    header: _header,
+                    suggestion: function (suggestion) {
+                        var suggestionHtml = '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
+                                '<div class="algolia-docsearch-suggestion--wrapper">' +
+                                '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
+                                '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
+                                '</div>' +
+                                '<div class="algolia-docsearch-suggestion--content">' +
+                                '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
+                                '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2) + '</div>' +
+                                displaySnippet(suggestion) +
+                                '</div>' +
+                                '</div>' +
+                                '</div>';
+                        return wrap(suggestionHtml, wrapper)
+                    }
+                };
+                if (useFooter) {
+                    _templates['footer'] = '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>';
+                }
 
-              return {
-                  source: autocomplete.sources.hits(
-                    _indexObj,
-                    {hitsPerPage: _hitsPerPage, facetFilters: _faceFilters }
-                  )
-                  ,
-                  templates: _templates
-              };
+                return {
+                    source: autocomplete.sources.hits(
+                            _indexObj,
+                            {hitsPerPage: _hitsPerPage, facetFilters: _faceFilters}
+                    )
+                    ,
+                    templates: _templates
+                };
 
+            };
+
+            var lagomFacetFilters = ['version:current'];
+            var akkaFacetFilters = [];
+            var playFacetFilters = ['version:2.6.x', 'tags:en'];
+
+            var useScalaFacetFilter = window.location.href.split('/').includes("scala");
+            if (useScalaFacetFilter) {
+                lagomFacetFilters.push('language:scala');
+                akkaFacetFilters.push('language:scala');
+            } else {
+                lagomFacetFilters.push('language:java');
+                akkaFacetFilters.push('language:java');
             }
+
 
             autocomplete('#cross-docs-search',
-                    { hint: false },
+                    {hint: false},
                     [
-                      // TODO: parameterize language depending on current page
-                      buildIndexSettings(lagomIndex, 5, [ 'language:scala', 'version:current' ], "Lagom Documentation", false)
-                      ,
-                      // TODO: parameterize language depending on current page
-                      buildIndexSettings(akkaIndex, 2, [ 'language:scala' ], "Akka Documentation", false, "akka")
-                      ,
-                      buildIndexSettings(playIndex, 2, ['version:2.6.x', 'tags:en'], "Play Documentation", true, "play")
+                        buildIndexSettings(lagomIndex, 5, lagomFacetFilters, "Lagom Documentation", false)
+                        ,
+                        buildIndexSettings(akkaIndex, 2, akkaFacetFilters, "Akka Documentation", false, "akka")
+                        ,
+                        buildIndexSettings(playIndex, 2, playFacetFilters, "Play Documentation", true, "play")
                     ]
-                    ).on('autocomplete:selected', function(event, suggestion, dataset) {
-                              location.href = suggestion.url;
-                    });
+            ).on('autocomplete:selected', function (event, suggestion, dataset) {
+                location.href = suggestion.url;
+            });
     </script>
 
 
-
-    @for(script <- context.resources.scripts) {<script type="text/javascript" src="@script"></script>
+    @for(script <- context.resources.scripts) {
+        <script type="text/javascript" src="@script"></script>
     }
-} {  @* Body *@
+} { @* Body *@
     <header class="fw-wrapper lgm-purple page-title">
         <div class="row">
             <div class="small-12 columns">
@@ -119,7 +132,8 @@
                     <nav class="breadcrumbs">
                         <a href="@nav.head.url">@nav.head.title</a>
                         @for(section <- nav.drop(1)) {
-                            &raquo; <a href="@section.url">@section.title</a>
+                                    &raquo;
+                            <a href="@section.url">@section.title</a>
                         }
                     </nav>
                 }
@@ -134,14 +148,20 @@
                             <strong>Next:</strong>
                             <ul>
                             @for(link <- nextLinks) {
-                                <li><a href="@{link.url}">@link.title</a></li>
+                                <li><a href="@{
+                                    link.url
+                                }">@link.title</a>
+                                </li>
                             }
                             </ul>
                         </nav>
                     } else {
                         @for(link <- nextLinks) {
                             <nav class="next-link">
-                                <a href="@{link.url}"><strong>Next: </strong> @link.title</a>
+                                <a href="@{
+                                    link.url
+                                }"><strong>Next: </strong>
+                                    @link.title</a>
                             </nav>
                         }
                     }
@@ -149,7 +169,7 @@
 
                 @for(sourceUrl <- context.sourceUrl) {
                     <p class="edit-source">Found an error in this documentation? The source code for this page can be found
-                        <a href="@sourceUrl">here</a>. Please feel free to edit and contribute a pull request.</p>
+                        <a href="@sourceUrl">here</a>. Please feel free to edit and contribute a pull request. </p>
                 }
             </div>
             <aside class="small-12 large-4 columns">
@@ -160,11 +180,13 @@
                     <label for="docs-version">Version:</label>
                     <select id="docs-version">
                     @for(v <- versions) {
-                        <option value="@ctx.path/documentation/@v.name/@language@if(v.exists){/@path}else{/Home.html}"@if(v.name == version){ selected="selected"}>@v.name</option>
+                        <option value="@ctx.path/documentation/@v.name/@language @if(v.exists) {/@path} else {/Home.html}" @if(v.name == version) {
+                            selected="selected"}>@v.name</option>
                     }
                     </select>
 
-                    <a href="@ctx.path/documentation/@version/@language/api/index.html" class="api-docs">API Documentation</a>
+                    <a href="@ctx.path/documentation/@version/@language/api/index.html" class="api-docs">
+                        API Documentation</a>
 
                     @for(section <- nav.reverse) {
                         <h3>@section.title</h3>
@@ -181,5 +203,5 @@
                 </nav>
             </aside>
         </div>
-   </div>
+    </div>
 }

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -32,27 +32,47 @@
             var lagomIndex = clientLagom.initIndex('lagomframework');
             var akkaIndex = clientAkka.initIndex('akka_io');
             //initialize autocomplete on search input (ID selector must match)
-            autocomplete('#aa-cross-docs-search-input',
+
+            var displayValue = function (suggestion, level) {
+                if (level === 0)
+                    return suggestion._highlightResult.hierarchy.lvl0.value;
+                if (suggestion._highlightResult.hierarchy['lvl' + level] !== undefined) {
+                    return suggestion._highlightResult.hierarchy['lvl' + level].value ;
+                } else {
+                    return displayValue(suggestion, level - 1) ;
+                }
+            };
+
+            autocomplete('#cross-docs-search',
                     { hint: false },
                     [
-
                     // configure Lagom's index
                     {
                         source: autocomplete.sources.hits(lagomIndex,
                                 {
                                     hitsPerPage: 4,
-                                    facetFilters: ['language:scala', 'version:current' ]
+                                    facetFilters: [
+                                        'language:scala', // TODO: parameterize
+                                        'version:current' ]
                                 }),
                         //value to be displayed in input control after user's suggestion selection
                         // displayKey: 'lvl0',
                         //hash of templates used when rendering dataset
                         templates: {
-                            header: '<div class="aa-suggestions-category">Lagom</div>',
+                            header: '<span class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main algolia-docsearch-suggestion__secondary algolia-docsearch-suggestion--category-header ">Lagom Documentation</span>',
                             //'suggestion' templating function used to render a single suggestion
                             suggestion: function(suggestion) {
-                                return '<span>' +
-                                        suggestion._highlightResult.hierarchy.lvl0.value + '</span><span>' +
-                                        suggestion._highlightResult.hierarchy.lvl1.value + '</span>';
+                                return  '        <div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
+                                 '<div class="algolia-docsearch-suggestion--wrapper">' +
+                                    '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
+                                        '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
+                                    '</div>' +
+                                    '<div class="algolia-docsearch-suggestion--content">' +
+                                        '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
+                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</span></div>' +
+                                    '</div>' +
+                                '</div>'+
+                              '</div>';
                             }
                         }
                     }
@@ -62,25 +82,38 @@
                         source: autocomplete.sources.hits(akkaIndex,
                                 {
                                     hitsPerPage: 4,
-                                    facetFilters: ['language:scala']
+                                    facetFilters: ['language:scala'] // TODO: parameterize
                                     // akka_io only indexes 'current'
                                 }),
                         //value to be displayed in input control after user's suggestion selection
                         // displayKey: 'lvl0',
                         //hash of templates used when rendering dataset
                         templates: {
-                            header: '<div class="aa-suggestions-category">Akka</div>',
+                            // last item on the list must include the algolia footer
+                            footer: '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>',
+                            header: '<span class="akka"><span class="algolia-docsearch-suggestion algolia-docsearch-suggestion--category-header ">Akka Documentation</span></span>',
                             //'suggestion' templating function used to render a single suggestion
                             suggestion: function(suggestion) {
-                                return '<span>' +
-                                        suggestion._highlightResult.hierarchy.lvl0.value + '</span><span>' +
-                                        suggestion._highlightResult.hierarchy.lvl1.value + '</span>';
+                                return '<span class="akka">'+
+                                '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
+                                        '<div class="algolia-docsearch-suggestion--wrapper">' +
+                                        '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
+                                        '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
+                                        '</div>' +
+                                        '<div class="algolia-docsearch-suggestion--content">' +
+                                        '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
+                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</span></div>' +
+                                        '</div>' +
+                                        '</div>' +
+                                        '</div>' +
+                                        '</span>';
                             }
                         }
                     }
-
                     ]
-                    );
+                    ).on('autocomplete:selected', function(event, suggestion, dataset) {
+                              location.href = suggestion.url;
+                    });
     </script>
 
 
@@ -139,15 +172,7 @@
             <aside class="small-12 large-4 columns">
                 <nav class="side-menu">
 
-
-                    <div class="aa-input-container" id="aa-input-container">
-                        <input type="search" id="aa-cross-docs-search-input" class="aa-input-search" placeholder="Search other projects..." name="search" autocomplete="off" />
-                        <svg class="aa-input-icon" viewBox="654 -372 1664 1664">
-                            <path d="M1806,332c0-123.3-43.8-228.8-131.5-316.5C1586.8-72.2,1481.3-116,1358-116s-228.8,43.8-316.5,131.5  C953.8,103.2,910,208.7,910,332s43.8,228.8,131.5,316.5C1129.2,736.2,1234.7,780,1358,780s228.8-43.8,316.5-131.5  C1762.2,560.8,1806,455.3,1806,332z M2318,1164c0,34.7-12.7,64.7-38,90s-55.3,38-90,38c-36,0-66-12.7-90-38l-343-342  c-119.3,82.7-252.3,124-399,124c-95.3,0-186.5-18.5-273.5-55.5s-162-87-225-150s-113-138-150-225S654,427.3,654,332  s18.5-186.5,55.5-273.5s87-162,150-225s138-113,225-150S1262.7-372,1358-372s186.5,18.5,273.5,55.5s162,87,225,150s113,138,150,225  S2062,236.7,2062,332c0,146.7-41.3,279.7-124,399l343,343C2305.7,1098.7,2318,1128.7,2318,1164z" />
-                        </svg>
-                    </div>
-
-
+                    <input type="search" id="cross-docs-search" placeholder="Search other projects..." />
 
                     <input type="text" id="docs-search" placeholder="Search"/>
 

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -40,97 +40,59 @@
               }
             }
 
+            var wrap = function(content, wrapper){
+              if(typeof wrapper !== 'undefined'){
+                return '<span class='+wrapper+'>' + content + '</span>';
+              } else {
+                return content;
+              }
+            }
+
+            var buildIndexSettings = function(_indexObj, _hitsPerPage, _faceFilters, title, useFooter, wrapper) {
+              var _header = wrap('<span class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main algolia-docsearch-suggestion__secondary algolia-docsearch-suggestion--category-header ">'+title+'</span>', wrapper);
+              var _templates =  {
+                                    header: _header,
+                                    suggestion: function(suggestion) {
+                                        var suggestionHtml = '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
+                                         '<div class="algolia-docsearch-suggestion--wrapper">' +
+                                            '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
+                                                '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
+                                            '</div>' +
+                                            '<div class="algolia-docsearch-suggestion--content">' +
+                                                '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
+                                                '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
+                                                displaySnippet(suggestion) +
+                                            '</div>' +
+                                        '</div>'+
+                                      '</div>';
+                                      return wrap(suggestionHtml, wrapper)
+                                    }
+                                };
+              if(useFooter){
+                _templates['footer'] = '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>';
+              }
+
+              return {
+                  source: autocomplete.sources.hits(
+                    _indexObj,
+                    {hitsPerPage: _hitsPerPage, facetFilters: _faceFilters }
+                  )
+                  ,
+                  templates: _templates
+              };
+
+            }
+
             autocomplete('#cross-docs-search',
                     { hint: false },
                     [
-                    // configure Lagom's index
-                    {
-                        source: autocomplete.sources.hits(lagomIndex,
-                                {
-                                    hitsPerPage: 5,
-                                    facetFilters: [
-                                        'language:scala', // TODO: parameterize
-                                        'version:current' ]
-                                }),
-                        templates: {
-                            header: '<span class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main algolia-docsearch-suggestion__secondary algolia-docsearch-suggestion--category-header ">Lagom Documentation</span>',
-                            suggestion: function(suggestion) {
-                                return  '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
-                                 '<div class="algolia-docsearch-suggestion--wrapper">' +
-                                    '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
-                                        '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
-                                    '</div>' +
-                                    '<div class="algolia-docsearch-suggestion--content">' +
-                                        '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
-                                        displaySnippet(suggestion) +
-                                    '</div>' +
-                                '</div>'+
-                              '</div>';
-                            }
-                        }
-                    }
-                    ,
-                    // configure Akka's index
-                    {
-                        source: autocomplete.sources.hits(akkaIndex,
-                                {
-                                    hitsPerPage: 2,
-                                    facetFilters: ['language:scala'] // TODO: parameterize
-                                    // akka_io only indexes 'current'
-                                }),
-                        templates: {
-                            header: '<span class="akka"><span class="algolia-docsearch-suggestion algolia-docsearch-suggestion--category-header ">Akka Documentation</span></span>',
-                            //'suggestion' templating function used to render a single suggestion
-                            suggestion: function(suggestion) {
-                                return '<span class="akka">'+
-                                '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
-                                        '<div class="algolia-docsearch-suggestion--wrapper">' +
-                                        '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
-                                        '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
-                                        '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--content">' +
-                                        '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
-                                        displaySnippet(suggestion) +
-                                        '</div>' +
-                                        '</div>' +
-                                        '</div>' +
-                                        '</span>';
-                            }
-                        }
-                    }
-                    ,
-                    // configure Play's index
-                    {
-                        source: autocomplete.sources.hits(playIndex,
-                                {
-                                    hitsPerPage: 2,
-                                    facetFilters: ['version:2.6.x', 'tags:en']
-                                }),
-                        templates: {
-                            // last item on the list must include the algolia footer
-                            footer: '<div class="algolia-docsearch-footer"><a class="algolia-docsearch-footer--logo" href="https://www.algolia.com/docsearch">Algolia</a></div>',
-                            header: '<span class="play"><span class="algolia-docsearch-suggestion algolia-docsearch-suggestion--category-header ">Play Documentation</span></span>',
-                            //'suggestion' templating function used to render a single suggestion
-                            suggestion: function(suggestion) {
-                                return '<span class="play">'+
-                                '<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__secondary" style="white-space: normal;">' +
-                                        '<div class="algolia-docsearch-suggestion--wrapper">' +
-                                        '<div class="algolia-docsearch-suggestion--subcategory-column ">' +
-                                        '<span class="algolia-docsearch-suggestion--subcategory-column-text">' + displayValue(suggestion, 0) + '</span>' +
-                                        '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--content">' +
-                                        '<div class="algolia-docsearch-suggestion--subcategory-inline ">' + displayValue(suggestion, 1) + '</div>' +
-                                        '<div class="algolia-docsearch-suggestion--title algolia-docsearch-suggestion--duplicate-content">' + displayValue(suggestion, 2)  +'</div>' +
-                                        displaySnippet(suggestion) +
-                                        '</div>' +
-                                        '</div>' +
-                                        '</div>' +
-                                        '</span>';
-                            }
-                        }
-                    }
+                      // TODO: parameterize language depending on current page
+                      buildIndexSettings(lagomIndex, 5, [ 'language:scala', 'version:current' ], "Lagom Documentation", false)
+                      ,
+                      // TODO: parameterize language depending on current page
+                      buildIndexSettings(akkaIndex, 2, [ 'language:scala' ], "Akka Documentation", false, "akka")
+                      ,
+                      buildIndexSettings(playIndex, 2, ['version:2.6.x', 'tags:en'], "Play Documentation", true, "play")
                     ]
                     ).on('autocomplete:selected', function(event, suggestion, dataset) {
                               location.href = suggestion.url;

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -91,10 +91,12 @@
             var useScalaFacetFilter = window.location.href.split('/').includes("scala");
             if (useScalaFacetFilter) {
                 lagomFacetFilters.push('language:scala');
-                akkaFacetFilters.push('language:scala');
+                // The Akka faceting for language is not active. Instead, the paradox grouping is used.
+                // akkaFacetFilters.push('language:scala');
             } else {
                 lagomFacetFilters.push('language:java');
-                akkaFacetFilters.push('language:java');
+                // The Akka faceting for language is not active. Instead, the paradox grouping is used.
+                // akkaFacetFilters.push('language:java');
             }
 
 


### PR DESCRIPTION
- [x] search multiple indices
 - [x] make each result set reuse look and feel from target project
 - [x] go to result page on click
 - [x] search only on `latest`
 - [x] search only for current `language` (only applies to akka and lagom)
 - [x] embed akka, play, lagom
 - [ ] ~embed akka-http~