### PR TITLE
Link Scala API doc to the scaladsl package

### DIFF
--- a/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
+++ b/src/main/scala/com/lightbend/lagom/docs/DocumentationGenerator.scala
@@ -282,7 +282,7 @@ object DocumentationGenerator extends App {
 
             val nextLinks = getNext(context)
 
-            val rendered = html.documentation(path, fileContent, context, version.language, version.name, versionPages, nav, canonical, nextLinks)
+            val rendered = html.documentation(path, fileContent, context, version, versionPages, nav, canonical, nextLinks)
 
             Files.write(targetFile.toPath, rendered.body.getBytes("utf-8"))
             OutputFile(targetFile, docsPath + "/" + path, includeInSitemap = true, "0.9")
@@ -374,6 +374,16 @@ case class Version(name: String, languages: Seq[LanguageVersion]) {
   */
 case class LanguageVersion(name: String, language: String, file: File, toc: TOC) {
   def pageFor(path: String) = VersionPage(name, toc.mappings.get(path).isDefined)
+
+  private val apiRoot = (name, language) match {
+    case (_, "java") => "api/index.html"
+    // Note that this version check will break and need to be updated if we ever have a 1.10+
+    case (version, "scala") if version >= "1.4" => "api/com/lightbend/lagom/scaladsl/index.html"
+    case (version, "scala") if version < "1.4" => "api/index.html#com.lightbend.lagom.scaladsl.package"
+  }
+
+  def referenceManualPath(implicit ctx: LagomContext) = s"${ctx.path}/documentation/$name/$language/Home.html"
+  def apiDocPath(implicit ctx: LagomContext) = s"${ctx.path}/documentation/$name/$language/$apiRoot"
 }
 
 /**

--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -2,9 +2,10 @@
 @import com.lightbend.lagom.docs.VersionPage
 @import com.lightbend.lagom.docs.Section
 @import com.lightbend.lagom.docs.LagomContext
+@import com.lightbend.lagom.docs.LanguageVersion
 @import com.lightbend.lagom.docs.NavLink
 
-@(path: String, content: Html, context: Context, language: String, version: String, versions: Seq[VersionPage], nav: List[Section],
+@(path: String, content: Html, context: Context, lang: LanguageVersion, versions: Seq[VersionPage], nav: List[Section],
         canonical: Option[String], nextLinks: Seq[NavLink])(implicit ctx: LagomContext)
 
 @main(Some(context.title), canonical) { @* Header *@
@@ -182,12 +183,12 @@
                     <label for="docs-version">Version:</label>
                     <select id="docs-version">
                     @for(v <- versions) {
-                        <option value="@ctx.path/documentation/@v.name/@language @if(v.exists) {/@path} else {/Home.html}" @if(v.name == version) {
+                        <option value="@ctx.path/documentation/@v.name/@lang.language @if(v.exists) {/@path} else {/Home.html}" @if(v.name == lang.name) {
                             selected="selected"}>@v.name</option>
                     }
                     </select>
 
-                    <a href="@ctx.path/documentation/@version/@language/api/index.html" class="api-docs">
+                    <a href="@lang.apiDocPath" class="api-docs">
                         API Documentation</a>
 
                     @for(section <- nav.reverse) {

--- a/src/main/twirl/com/lightbend/lagom/docs/documentationIndex.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentationIndex.scala.html
@@ -12,7 +12,7 @@
     @for(version <- versions.find(_.name == summary.name)) {
         <ul>
         @for(lang <- version.languages) {
-            <li>@toTitleCase(lang.language): <a href="@ctx.path/documentation/@version.name/@lang.language/Home.html">Reference manual</a> and <a href="@ctx.path/documentation/@version.name/@lang.language/api/index.html">API docs</a>.</li>
+            <li>@toTitleCase(lang.language): <a href="@lang.referenceManualPath">Reference manual</a> and <a href="@lang.apiDocPath">API docs</a>.</li>
             }
         </ul>
     }

--- a/src/main/twirl/com/lightbend/lagom/docs/documentationVersionIndex.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentationVersionIndex.scala.html
@@ -12,8 +12,8 @@
         <h3>@toTitleCase(lang.language)</h3>
 
         <ul>
-            <li><a href="@ctx.path/documentation/@version.name/@lang.language/Home.html">Reference manual</a></li>
-            <li><a href="@ctx.path/documentation/@version.name/@lang.language/api/index.html">API docs</a></li>
+            <li><a href="@lang.referenceManualPath">Reference manual</a></li>
+            <li><a href="@lang.apiDocPath">API docs</a></li>
         </ul>
     }
 


### PR DESCRIPTION
Changes the front page of the API documentation from the [blank-looking `root` package](https://www.lagomframework.com/documentation/1.4.x/scala/api/index.html) (requiring many clicks to navigate somewhere useful) to point to the [`com.lightbend.lagom.scaladsl`](https://www.lagomframework.com/documentation/1.4.x/scala/api/com/lightbend/lagom/scaladsl/index.html) package instead.

Thanks to @zbeckman for the suggestion!