### PR TITLE
Remove FAQ item about ConductR

### DIFF
--- a/src/main/markdown/faq.md
+++ b/src/main/markdown/faq.md
@@ -41,9 +41,3 @@ See more in the Lagom documentation on [Managing data persistence](/documentatio
 Yes, Lagom supports extensible serialization, both for messages transmitted between different services and for internal messages and persistent data used within a service. JSON is supported by default, as it is simple and well understood. Services that require higher performance or more compact data can use alternatives such as [Protocol Buffers](https://developers.google.com/protocol-buffers/), [Apache Avro](http://avro.apache.org/), [Kryo](https://github.com/EsotericSoftware/kryo), or any other serializer that you choose.
 
 See more in the Lagom documentation on Message Serializers ([Java](/documentation/current/java/MessageSerializers.html)/[Scala](/documentation/current/scala/MessageSerializers.html)) and Persistent Entity Serialization ([Java](/documentation/current/java/Serialization.html)/[Scala](/documentation/current/scala/Serialization.html)).
-
-## Do I have to use ConductR to deploy Lagom services? Can I deploy with Kubernetes?
-
-Lagom doesn't prescribe any particular production environment, however out of the box support for Lagom is provided by [Lightbend ConductR](https://www.lightbend.com/products/conductr). If you are interested in deploying on [Kubernetes](https://kubernetes.io/), see our guide that demonstrates [how to deploy the Chirper example application](https://developer.lightbend.com/guides/k8s-microservices/).
-
-For more information on running Lagom services in production, see the [Java documentation](/documentation/current/java/ProductionOverview.html) or the [Scala documentation](/documentation/current/scala/ProductionOverview.html)


### PR DESCRIPTION
I wasn't sure whether to update the question or remove it, so I went with the simpler option. WDYT? It's not such a frequently asked question these days (though now we do get some "Do I have to use Kubernetes?")

The only remaining references to ConductR on the site now are in docs for old versions, release announcements and other blog posts. Most of these are historical, so we don't need to update them. The only one I'm not sure about is https://www.lagomframework.com/blog/microservices-from-development-to-production.html @kwehden what do you think?