### PR TITLE
Update GitHub issue labels in "Get Involved"

### DIFF
--- a/src/main/twirl/com/lightbend/lagom/docs/getinvolved.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/getinvolved.scala.html
@@ -34,7 +34,7 @@
 
         <p>
             Even if you're not ready to fix issues yourself just yet, you can help out by verifying issues that have been reported by others.
-            Look for issues tagged with the <a href="https://github.com/lagom/lagom/labels/help%3Aneeds-verification">help:needs-verification</a> label.
+            Look for issues tagged with the <a href="https://github.com/lagom/lagom/labels/help%20wanted">"help wanted"</a> label.
             You can assist by looking at these issues and doing some checking to confirm whether they're bugs or not.
             You could provide reproducible tests or a sample project, or even just ask the original reporter for more information.
         </p>
@@ -48,8 +48,8 @@
 
         <p>
             You're welcome to work on any feature you like — Lagom is open source after all! — but if you'd like some good ideas, look for issues tagged with the
-            <a href="https://github.com/lagom/lagom/labels/help%3Anewbie">help:newbie</a> label and
-            <a href="https://github.com/lagom/lagom/labels/help%3Acommunity">help:community</a> label.
+            <a href="https://github.com/lagom/lagom/labels/help%20wanted">"help wanted"</a> or
+            <a href="https://github.com/lagom/lagom/labels/good%20first%20issue">"good first issue"</a> labels.
             These issues are ready and waiting for volunteers to pick them up.
         </p>
     </div>


### PR DESCRIPTION
- help:newbie is now "good first issue"
- help:community and help:needs-verification are now "help wanted"

These new labels match the GitHub conventions.