### PR TITLE
Add a link from the Maven announcement blog post to the Maven getting started guide

### DIFF
--- a/src/blog/introducing-maven-support.md
+++ b/src/blog/introducing-maven-support.md
@@ -9,6 +9,8 @@ summary: >
 
 ---
 
+**Update:** For the latest instructions on starting a Lagom project with Maven, see [Using Lagom with Java and Maven](/get-started-java-maven.html).
+
 The Lagom team are proud to announce the introduction of Maven support for Lagom!  We've published Lagom 1.1.0-RC1 with this support, and are keen to get feedback from users to see if it works.
 
 ## Why Maven?


### PR DESCRIPTION
This blog post appears as the top result from the Lagom web site when searching for "lagom maven" on Google. This might lead people to follow the instructions in the post and end up with an old version of the Maven archetype.

CC: @WadeWaldron