### PR TITLE
Remove canonical reference from 1.5.0 blog

### DIFF
--- a/src/blog/lagom-1-5-0.md
+++ b/src/blog/lagom-1-5-0.md
@@ -3,7 +3,6 @@ title: "Lagom 1.5 Released: Akka Management, Kubernetes, OpenShift, gRPC, Couchb
 date: 2019-04-16
 author_github: ignasi35
 tags: news
-canonical_rel: https://www.lightbend.com/blog/lagom-1-5-released-akka-management-kubernetes-openshift-grpc-couchbase
 summary: >
     The Lagom team has released Lagom 1.5.0
 


### PR DESCRIPTION
Discussed with @theotown and this is no longer required. We hope this will improve search results for the 1.5.0 announcement.