### PR TITLE
Remove Travis success check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 pull_request_rules:
   - name: Merge PRs that are ready
     conditions:
-      - status-success=Travis CI - Pull Request
       - status-success=typesafe-cla-validator
       - "#approved-reviews-by>=1"
       - "#review-requested=0"


### PR DESCRIPTION
Reviewing why https://github.com/lagom/lagom.github.io/pull/213 was not merged by `mergify` I noticed https://github.com/lagom/lagom.github.io doesn’t have any CI job configured.