### PR TITLE
Mergify: remove auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,27 +1,6 @@
 pull_request_rules:
-  - name: Merge PRs that are ready
-    conditions:
-      - status-success=typesafe-cla-validator
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
-      - label!=status:block-merge
-    actions:
-      merge:
-        method: merge
-        strict: smart
-
   - name: Delete the PR branch after merge
     conditions:
       - merged
     actions:
       delete_head_branch: {}
-
-  - name: auto add wip
-    conditions:
-      # match a few flavours of wip
-      - title~=^(\[wip\]( |:) |\[WIP\]( |:) |wip( |:) |WIP( |:)).*
-    actions:
-      label:
-        add: ["status:block-merge"]
-


### PR DESCRIPTION
I just realised that we don't need mergify here. There is no CI for the docs, so the reviewer either approve and merge it, or approve and let it wait to be merged later. 

That's exactly the case for PR #226. I want to approve it, but the release isn't done yet. So we want to wait for it. I almost approved and that would trigger the publication of the website.