### PR TITLE
Disable cross-site search

### DIFF
--- a/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
+++ b/src/main/twirl/com/lightbend/lagom/docs/documentation.scala.html
@@ -19,11 +19,7 @@
         <!-- Cross-site search. This is using Algolia's autocomplete.js  -->
     <script>
             var clientLagom = algoliasearch('BH4D9OD16A', '77ef1e29e6bddfca861f7a42cc51725e');
-            var clientAkka = algoliasearch('BH4D9OD16A', '543bad5ad786495d9ccd445ed34ed082');
-            var clientPlay = algoliasearch('BH4D9OD16A', 'a0b34e68c804cf96e76adcb02d47159b');
             var lagomIndex = clientLagom.initIndex('lagomframework');
-            var akkaIndex = clientAkka.initIndex('akka_io');
-            var playIndex = clientPlay.initIndex('playframework');
 
             var displayValue = function (suggestion, level) {
                 if (level === 0)
@@ -86,29 +82,19 @@
             };
 
             var lagomFacetFilters = ['version:current'];
-            var akkaFacetFilters = [];
-            var playFacetFilters = ['version:2.6.x', 'tags:en'];
 
             var useScalaFacetFilter = window.location.href.split('/').includes("scala");
             if (useScalaFacetFilter) {
                 lagomFacetFilters.push('language:scala');
-                // The Akka faceting for language is not active. Instead, the paradox grouping is used.
-                // akkaFacetFilters.push('language:scala');
             } else {
                 lagomFacetFilters.push('language:java');
-                // The Akka faceting for language is not active. Instead, the paradox grouping is used.
-                // akkaFacetFilters.push('language:java');
             }
 
 
             autocomplete('#cross-docs-search',
                     {hint: false},
                     [
-                        buildIndexSettings(lagomIndex, 5, lagomFacetFilters, "Lagom Documentation", false)
-                        ,
-                        buildIndexSettings(akkaIndex, 2, akkaFacetFilters, "Akka Documentation", false, "akka")
-                        ,
-                        buildIndexSettings(playIndex, 2, playFacetFilters, "Play Documentation", true, "play")
+                        buildIndexSettings(lagomIndex, 10, lagomFacetFilters, "Lagom Documentation", false)
                     ]
             ).on('autocomplete:selected', function (event, suggestion, dataset) {
                 location.href = suggestion.url;


### PR DESCRIPTION
Cross-index search is now more strict on the Algolia side. The JS implementation used to gather all the facets and index details and do a single HTTP request. With the new API verifications I guess we would need to send 3 separate requests.

To test this. Checkout the PR and use `sbt run`. Then open localhost:8080 and use the search functionality in the docs.